### PR TITLE
Upgrade ioctl-sys version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords    = ["linux", "input"]
 
 [dependencies]
 libc      = "0.2"
-ioctl-sys = "0.5"
+ioctl-sys = "0.8.0"


### PR DESCRIPTION
This PR upgrades the ioctl-sys version to 0.80.